### PR TITLE
Handle initial size and resizing more reliably

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,6 @@ name = "wgpu_starter"
 version = "0.1.0"
 edition = "2021"
 
-[lib]
-name = "wgpu_start"
-crate-type = ["cdylib", "rlib"]
- 
 [dependencies]
 winit = { version = "0.30.5" }
 env_logger = {version = "0.11.5"}
@@ -21,10 +17,4 @@ cfg-if = "1"
 console_error_panic_hook = "0.1.7"
 console_log = "1.0"
 wgpu = { version = "23.0.1", features = ["webgl"]}
-wasm-bindgen = "0.2.99"
 wasm-bindgen-futures = "0.4.49"
-web-sys = { version = "0.3.76", features = [
-    "Document",
-    "Window",
-    "Element",
-]}

--- a/index.html
+++ b/index.html
@@ -5,51 +5,23 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link data-trunk rel="rust" data-bin="wgpu_starter" />`
+    <link data-trunk rel="rust" data-bin="wgpu_starter" />
     <!-- <link data-trunk rel="rust" data-target-name="wgpu_starter" /> -->
     <title>Learn WGPU</title>
     <style type="text/css">
-            :focus {
-                outline: none;
-            }
-
-            body,
-            html {
+            body {
                 margin: 0;
-                padding: 0;
-                width: 100%;
-                height: 100%;
-                overflow: hidden;
             }
-
-            .root {
-                width: 100%;
-                height: 100%;
-                display: flex;
-                justify-content: center;
-                align-items: center;
-            }
-
-            .main-canvas {
+            canvas {
                 display: block;
-               
+                width: 100vw;
+                height: 100vh;
+            }
+            canvas:focus {
+                outline: none
             }
         </style>
 </head>
-
-<body id="wasm-example">
-<!--   <script type="module">
-      import init from "./pkg/learn_wgpu_.js";
-      init().then(() => {
-          console.log("WASM Loaded");
-      });
-  </script> -->
-  <div class="root">
-    <canvas class="main-canvas" id="canvas" width="600" height="600"></canvas>
-  </div>
-
-
-
-</body>
+<body></body>
 
 </html>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,0 @@
-#[cfg(target_arch="wasm32")]
-use wasm_bindgen::prelude::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,11 +11,7 @@ pub mod vertex;
 
 pub mod utils;
 
-#[cfg(target_arch="wasm32")]
-use wasm_bindgen::prelude::wasm_bindgen;
-
-#[cfg_attr(target_arch="wasm32", wasm_bindgen(start))]
-fn run() {
+fn main() {
     
         cfg_if::cfg_if! {
             if #[cfg(target_arch = "wasm32")] {
@@ -39,7 +35,4 @@ fn run() {
         let _ = event_loop.run_app(&mut app);
         //let mut state = State::new(&app);
 
-}
-fn main()  {
-    run();
 }


### PR DESCRIPTION
This is a general issue with working with Winit: when something doesn't work, an attempted fix might only work with your specific setup and platform. Handling these kinds of issues while preserving portability is hard without knowing all the details and reading the lackluster documentation very carefully.

- Don't cache size. We can always get it with `Window::inner_size()`.
- Only request a re-draw when size has actually changed. `WindowEvent::Resized` is not guaranteed to fire with a different size than before.
- Never call `Surface::configure()` unless the size is bigger than 0.
- Never call `Surface::configure()` if the size hasn't changed. It's expensive!
- Never render if the size is zero. The surface might not be configured yet (if we started the application with a size of 0) and there is no point!

I also removed/simplified all the Web specific stuff that isn't necessary:
- Web works perfectly fine with a `main.rs`. No need to go through the `cdylib` hassle. Note: the resulting Wasm module will be slightly bigger, but entirely insignificant compared to Winit + Wgpu.
- The `index.html` can be empty, we only need a bit of CSS. If your intention is that the canvas is as big as the window, the CSS can be simplified a lot as well.
- `WindowAttributes::with_append()` is all you need really. Winit generates its own canvas which it inserts.

~~Based on #1.~~